### PR TITLE
ASDPLNG-323: Fix typo in hiera rhsm::proxy::hostname

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,5 +3,5 @@ rhsm::activationkey: ""  # IDEALLY LOOKED UP VIA VAULT
 rhsm::enabled: true
 rhsm::manage_repos: true
 rhsm::org: ""            # IDEALLY LOOKED UP VIA VAULT
-rhsm::proxy::host: ""
+rhsm::proxy::hostname: ""
 rhsm::proxy::port: ""


### PR DESCRIPTION
`./data/common.yaml` was setting `rhsm::proxy::host` instead of `rhsm::proxy::hostname`.

This is being tested on `control-pup01`.

This is such a minor change/fix that it doesn't really need review. But I'm following the standard pull request process so that others are aware of the change. Note also that I'm going to delete the current tag `v0.1.4` that I created earlier today and replace it with this change. This is not what we normally want to do, but in this particular case I think it makes sense.

