### PR TITLE
SVCPLAN-1587 Fix fact 'rhsm_manage_repo' for Centos hosts

### DIFF
--- a/lib/facter/rhsm_manage_repo.rb
+++ b/lib/facter/rhsm_manage_repo.rb
@@ -1,5 +1,5 @@
 Facter.add('rhsm_manage_repo') do
-  confine osfamily: 'RedHat'
+  confine operatingsystem: 'RedHat'
   setcode do
     rhsm_result = Facter::Util::Resolution.exec('subscription-manager config --list  | grep manage_repos | awk \'{ print $NF}\'')
     case rhsm_result


### PR DESCRIPTION
The rhsm_manage_repo fact is running on CentOS hosts when it should not

The confine statement is using the wrong fact